### PR TITLE
Fix missing semaphore signal

### DIFF
--- a/gapis/api/templates/vulkan_gfx_api_extras.tmpl
+++ b/gapis/api/templates/vulkan_gfx_api_extras.tmpl
@@ -46,6 +46,7 @@
 ¶
   #define __STDC_FORMAT_MACROS
   #include <inttypes.h>
+  #include <unistd.h>
 ¶
   namespace gapir {«
 ¶
@@ -366,6 +367,8 @@ bool Vulkan::replayGetFenceStatus(Stack* stack, bool pushReturn) {
               // to vkWaitForFences() once the issue is fixed.
               do {
                 return_value = mVkDeviceFunctionStubs[device].vkGetFenceStatus(device, fence);
+                GAPID_DEBUG("vkGetFenceStatus(%" PRIsize ", %" PRIu64 ") expect return 0x0, actual return value: 0x%X", device, fence, return_value);
+                usleep(3000);
               } while (return_value != gapir::Vulkan::VkResult::VK_SUCCESS &&
                          return_value != gapir::Vulkan::VkResult::VK_ERROR_DEVICE_LOST);
             } else {

--- a/gapis/api/templates/vulkan_gfx_api_extras.tmpl
+++ b/gapis/api/templates/vulkan_gfx_api_extras.tmpl
@@ -46,7 +46,6 @@
 ¶
   #define __STDC_FORMAT_MACROS
   #include <inttypes.h>
-  #include <unistd.h>
 ¶
   namespace gapir {«
 ¶
@@ -367,8 +366,6 @@ bool Vulkan::replayGetFenceStatus(Stack* stack, bool pushReturn) {
               // to vkWaitForFences() once the issue is fixed.
               do {
                 return_value = mVkDeviceFunctionStubs[device].vkGetFenceStatus(device, fence);
-                GAPID_DEBUG("vkGetFenceStatus(%" PRIsize ", %" PRIu64 ") expect return 0x0, actual return value: 0x%X", device, fence, return_value);
-                usleep(3000);
               } while (return_value != gapir::Vulkan::VkResult::VK_SUCCESS &&
                          return_value != gapir::Vulkan::VkResult::VK_ERROR_DEVICE_LOST);
             } else {


### PR DESCRIPTION
In state_rebuilder.go, we should also signal the semaphores that are signaled by `vkAcquireNextImageKHR`.

In footprint_builder.go, we should handle the case that vkQueueSubmit does not contain any commands.

This PR also fix the missing layout transition for images that are not single sampled, or not a color aspect image. And bring back the missing commandbuffer inheritance info.